### PR TITLE
Add www to expkv link for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Day   | Package   | Link
 08/08 | lua-typo  | https://www.ctan.org/pkg/lua-typo
 09/08 | awesomebox | https://www.ctan.org/pkg/awesomebox
 10/08 | aeb_dad   | https://www.ctan.org/pkg/aeb_dad
-11/08 | expkv     | https://ctan.org/pkg/expkv
+11/08 | expkv     | https://www.ctan.org/pkg/expkv
 12/08 | ticollege | https://www.ctan.org/pkg/ticollege
 13/08 |  |
 14/08 |  |


### PR DESCRIPTION
Although I would personally prefer to remove all "www" from the links.